### PR TITLE
fix: add requirements.txt for demo

### DIFF
--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,0 +1,2 @@
+git+https://github.com/aphp/edspdf.git
+streamlit


### PR DESCRIPTION
This PR fixes the Streamlit demo by adding a requirements file.