### PR TITLE
Huggingface multi-modal transformers

### DIFF
--- a/docs/pipes/embeddings/huggingface-embedding.md
+++ b/docs/pipes/embeddings/huggingface-embedding.md
@@ -1,0 +1,7 @@
+# HuggingfaceEmbedding {: #edspdf.pipes.embeddings.huggingface_embedding.HuggingfaceEmbedding }
+
+::: edspdf.pipes.embeddings.huggingface_embedding.HuggingfaceEmbedding
+    options:
+        heading_level: 2
+        show_bases: false
+        show_source: false

--- a/docs/pipes/embeddings/index.md
+++ b/docs/pipes/embeddings/index.md
@@ -10,13 +10,14 @@ td:nth-child(1), td:nth-child(2) {
 }
 </style>
 
-| Factory name                                                                                 |  Description                                                       |
-|----------------------------------------------------------------------------------------------|--------------------------------------------------------------------|
-| [`simple-text-embedding`][edspdf.pipes.embeddings.simple_text_embedding.SimpleTextEmbedding] |  A module that embeds the textual features of the blocks.          |
-| [`embedding-combiner`][edspdf.pipes.embeddings.embedding_combiner.EmbeddingCombiner]         |  Encodes boxes using a combination of multiple encoders            |
-| [`sub-box-cnn-pooler`][edspdf.pipes.embeddings.sub_box_cnn_pooler.SubBoxCNNPooler]           |  Pools the output of a CNN over the elements of a box (like words) |
-| [`box-layout-embedding`][edspdf.pipes.embeddings.box_layout_embedding.BoxLayoutEmbedding]    |  Encodes the layout of the boxes                                   |
-| [`box-transformer`][edspdf.pipes.embeddings.box_transformer.BoxTransformer]                  |  Contextualizes box representations using a transformer            |
+| Factory name                                                                                  | Description                                                       |
+|-----------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
+| [`simple-text-embedding`][edspdf.pipes.embeddings.simple_text_embedding.SimpleTextEmbedding]  | A module that embeds the textual features of the blocks.          |
+| [`embedding-combiner`][edspdf.pipes.embeddings.embedding_combiner.EmbeddingCombiner]          | Encodes boxes using a combination of multiple encoders            |
+| [`sub-box-cnn-pooler`][edspdf.pipes.embeddings.sub_box_cnn_pooler.SubBoxCNNPooler]            | Pools the output of a CNN over the elements of a box (like words) |
+| [`box-layout-embedding`][edspdf.pipes.embeddings.box_layout_embedding.BoxLayoutEmbedding]     | Encodes the layout of the boxes                                   |
+| [`box-transformer`][edspdf.pipes.embeddings.box_transformer.BoxTransformer]                   | Contextualizes box representations using a transformer            |
+| [`huggingface-embedding`][edspdf.pipes.embeddings.huggingface_embedding.HuggingfaceEmbedding] | Box representations using a Huggingface multi-modal model.        |
 
 <!-- --8<-- [end:components] -->
 

--- a/docs/recipes/training.md
+++ b/docs/recipes/training.md
@@ -190,10 +190,10 @@ def segmentation_adapter(
 
 ## Full example
 
-Let's wrap the training code in a function, and make it callable from the command line !
+Let's wrap the training code in a function, and make it callable from the command line using [confit](https://github.com/aphp/confit) !
 
 ???+ example "train.py"
-    ```python linenums="1" hl_lines="16-27"
+    ```python linenums="1"
     import itertools
     import json
     from pathlib import Path

--- a/docs/recipes/training.md
+++ b/docs/recipes/training.md
@@ -63,7 +63,6 @@ model to decrease a given loss. The process of training a pipeline with EDS-PDF 
         config={
             "embedding": model.get_pipe("embedding"),
             "labels": [],
-            "activation": "relu",
         },
     )
     ```
@@ -309,7 +308,6 @@ Let's wrap the training code in a function, and make it callable from the comman
             config={
                 "embedding": model.get_pipe("embedding"),
                 "labels": [],
-                "activation": "relu",
             },
         )
 
@@ -483,7 +481,6 @@ def train_my_model(
 -       config={
 -           "embedding": model.get_pipe("embedding"),
 -           "labels": [],
--           "activation": "relu",
 -       },
 -   )
 

--- a/edspdf/pipeline.py
+++ b/edspdf/pipeline.py
@@ -590,14 +590,19 @@ class Pipeline:
     def parameters(self):
         """Returns an iterator over the Pytorch parameters of the components in the
         pipeline"""
+        return (p for n, p in self.named_parameters())
+
+    def named_parameters(self):
+        """Returns an iterator over the Pytorch parameters of the components in the
+        pipeline"""
         seen = set()
         for name, component in self.pipeline:
-            if hasattr(component, "parameters"):
-                for param in component.parameters():
+            if hasattr(component, "named_parameters"):
+                for param_name, param in component.named_parameters():
                     if param in seen:
                         continue
                     seen.add(param)
-                    yield param
+                    yield f"{name}.{param_name}", param
 
     def to(self, device: Optional[torch.device] = None):
         """Moves the pipeline to a given device"""

--- a/edspdf/pipes/classifiers/trainable.py
+++ b/edspdf/pipes/classifiers/trainable.py
@@ -15,7 +15,6 @@ from edspdf.pipes.embeddings import EmbeddingOutput
 from edspdf.registry import registry
 from edspdf.structures import PDFDoc
 from edspdf.trainable_pipe import Scorer, TrainablePipe
-from edspdf.utils.torch import ActivationFunction, get_activation_function
 
 
 def classifier_scorer(pairs):
@@ -70,7 +69,6 @@ class TrainableClassifier(TrainablePipe[Dict[str, Any]]):
                     },
                 },
                 "labels": ["body", "pollution"],
-                "activation": "relu",
             },
         )
         ```
@@ -81,7 +79,6 @@ class TrainableClassifier(TrainablePipe[Dict[str, Any]]):
         [components.classifier]
         @factory = "trainable-classifier"
         labels = ["body", "pollution"]
-        activation = "relu"
 
         [components.classifier.embedding]
         @factory = "sub-box-cnn-pooler"
@@ -99,8 +96,6 @@ class TrainableClassifier(TrainablePipe[Dict[str, Any]]):
         Initial labels of the classifier (will be completed during initialization)
     embedding: TrainablePipe[EmbeddingOutput]
         Embedding module to encode the PDF boxes
-    activation: ActivationFunction
-        Name of the activation function
     dropout_p: float
         Dropout probability used on the output of the box and textual encoders
     scorer: Scorer
@@ -111,8 +106,6 @@ class TrainableClassifier(TrainablePipe[Dict[str, Any]]):
         self,
         embedding: TrainablePipe[EmbeddingOutput],
         labels: Sequence[str] = ("pollution",),
-        activation: ActivationFunction = "gelu",
-        dropout_p: float = 0.0,
         scorer: Scorer = classifier_scorer,
         pipeline: Pipeline = None,
         name: str = "trainable-classifier",
@@ -128,9 +121,6 @@ class TrainableClassifier(TrainablePipe[Dict[str, Any]]):
             in_features=self.embedding.output_size,
             out_features=len(self.label_voc),
         )
-        self.activation = get_activation_function(activation)
-        self.dropout = torch.nn.Dropout(dropout_p)
-
         # Scoring function
         self.score = scorer
 

--- a/edspdf/pipes/embeddings/box_layout_preprocessor.py
+++ b/edspdf/pipes/embeddings/box_layout_preprocessor.py
@@ -10,7 +10,6 @@ from edspdf.structures import PDFDoc
 BoxLayoutBatch = TypedDict(
     "BoxLayoutBatch",
     {
-        "page": FoldedTensor,
         "xmin": FoldedTensor,
         "ymin": FoldedTensor,
         "xmax": FoldedTensor,
@@ -62,10 +61,9 @@ class BoxLayoutPreprocessor(TrainablePipe[BoxLayoutBatch]):
 
     def preprocess(self, doc: PDFDoc, supervision: bool = False):
         pages = doc.pages
-        box_pages = [[b.page_num for b in page.text_boxes] for page in pages]
-        last_p = max((p for x in box_pages for p in x), default=0)
+        [[b.page_num for b in page.text_boxes] for page in pages]
+        last_p = doc.num_pages - 1
         return {
-            "page": box_pages,
             "xmin": [[b.x0 for b in p.text_boxes] for p in pages],
             "ymin": [[b.y0 for b in p.text_boxes] for p in pages],
             "xmax": [[b.x1 for b in p.text_boxes] for p in pages],
@@ -84,7 +82,6 @@ class BoxLayoutPreprocessor(TrainablePipe[BoxLayoutBatch]):
         }
 
         return {
-            "page": as_folded_tensor(batch["page"], dtype=torch.float, **kw),
             "xmin": as_folded_tensor(batch["xmin"], dtype=torch.float, **kw),
             "ymin": as_folded_tensor(batch["ymin"], dtype=torch.float, **kw),
             "xmax": as_folded_tensor(batch["xmax"], dtype=torch.float, **kw),

--- a/edspdf/pipes/embeddings/huggingface_embedding.py
+++ b/edspdf/pipes/embeddings/huggingface_embedding.py
@@ -62,7 +62,6 @@ class HuggingfaceEmbedding(TrainablePipe[EmbeddingOutput]):
         config={
             "embedding": model.get_pipe("embedding"),
             "labels": [],
-            "activation": "relu",
         },
     )
     ```

--- a/edspdf/pipes/embeddings/huggingface_embedding.py
+++ b/edspdf/pipes/embeddings/huggingface_embedding.py
@@ -256,12 +256,11 @@ class HuggingfaceEmbedding(TrainablePipe[EmbeddingOutput]):
         collated = {
             "input_ids": as_folded_tensor(batch["input_ids"], **kw, dtype=torch.long),
             "bbox": as_folded_tensor(batch["bbox"], **kw, dtype=torch.long),
-            "windows": windows,
-            "indexer": indexer[line_window_indices],
-            "line_window_indices": indexer[line_window_indices].as_tensor(),
-            "line_window_offsets_flat": line_window_offsets_flat,
+            "windows": windows.to(device),
+            "indexer": indexer[line_window_indices].to(device),
+            "line_window_indices": indexer[line_window_indices].as_tensor().to(device),
+            "line_window_offsets_flat": line_window_offsets_flat.to(device),
         }
-        print(windows_count_per_page)
         if self.use_image:
             collated["pixel_values"] = (
                 torch.stack(

--- a/edspdf/pipes/embeddings/huggingface_embedding.py
+++ b/edspdf/pipes/embeddings/huggingface_embedding.py
@@ -1,0 +1,288 @@
+import math
+
+import torch
+from foldedtensor import as_folded_tensor
+from transformers import AutoImageProcessor, AutoModel, AutoTokenizer
+from typing_extensions import Literal
+
+from edspdf import TrainablePipe, registry
+from edspdf.pipeline import Pipeline
+from edspdf.pipes.embeddings import EmbeddingOutput
+from edspdf.structures import PDFDoc
+
+
+def compute_contextualization_scores(windows):
+    ramp = torch.arange(0, windows.shape[1], 1)
+    scores = (
+        torch.min(ramp, windows.mask.sum(1, keepdim=True) - 1 - ramp)
+        .clamp(min=0)
+        .view(-1)
+    )
+    return scores
+
+
+@registry.factory.register("huggingface-embedding")
+class HuggingfaceEmbedding(TrainablePipe[EmbeddingOutput]):
+    """
+    The HuggingfaceEmbeddings component is a wrapper around the Huggingface multi-modal
+    models. Compared to using the raw Huggingface model, we offer a simple mechanism to
+    split long documents into strided windows before feeding them to the model.
+
+    Examples
+    --------
+
+    Here is an example of how to define a pipeline with the HuggingfaceEmbedding
+    component:
+
+    ```python
+    from edspdf import Pipeline
+
+    pipeline = Pipeline()
+    pipeline.add_pipe(
+        "mupdf-extractor",
+        name="extractor",
+        config={
+            "render_pages": True,
+        },
+    )
+    pipeline.add_pipe(
+        "huggingface-embedding",
+        name="embedding",
+        config={
+            "model": "microsoft/layoutlmv3-base",
+            "use_image": False,
+            "window": 128,
+            "stride": 64,
+            "line_pooling": "mean",
+        },
+    )
+    model.add_pipe(
+        "trainable-classifier",
+        name="classifier",
+        config={
+            "embedding": model.get_pipe("embedding"),
+            "labels": [],
+            "activation": "relu",
+        },
+    )
+    ```
+
+    This model can then be trained following the [training recipe](/recipes/training/).
+
+    Parameters
+    ----------
+    pipeline: Pipeline
+        The pipeline instance
+    name: str
+        The component name
+    model: str
+        The Huggingface model name or path
+    use_image: bool
+        Whether to use the image or not in the model
+    window: int
+        The window size to use when splitting long documents into smaller windows
+        before feeding them to the Transformer model (default: 510 = 512 - 2)
+    stride: int
+        The stride (distance between windows) to use when splitting long documents into
+        smaller windows: (default: 510 / 2 = 255)
+    line_pooling: Literal["mean", "max", "sum"]
+        The pooling strategy to use when combining the embeddings of the tokens in a
+        line into a single line embedding
+    """
+
+    def __init__(
+        self,
+        pipeline: Pipeline = None,
+        name: str = "huggingface-embedding",
+        model: str = None,
+        use_image: bool = True,
+        window: int = 510,
+        stride: int = 255,
+        line_pooling: Literal["mean", "max", "sum"] = "mean",
+    ):
+        super().__init__(pipeline, name)
+        self.use_image = use_image
+        self.image_processor = (
+            AutoImageProcessor.from_pretrained(model, apply_ocr=False)
+            if use_image
+            else None
+        )
+        self.tokenizer = AutoTokenizer.from_pretrained(model)
+        self.hf_model = AutoModel.from_pretrained(model)
+        self.output_size = self.hf_model.config.hidden_size
+        self.window = window
+        self.stride = stride
+        self.line_pooling = line_pooling
+
+    def preprocess(self, doc: PDFDoc):
+        res = {
+            "input_ids": [],
+            "bbox": [],
+            "windows": [],
+            "line_starts": [],
+        }
+        if self.use_image:
+            res["pixel_values"] = []
+
+        for page in doc.pages:
+            # Preprocess it using LayoutLMv3
+            prep = self.tokenizer(
+                text=[line.text for line in doc.text_boxes],
+                boxes=[
+                    (
+                        int(line.x0 * line.page.width),
+                        int(line.y0 * line.page.height),
+                        int(line.x1 * line.page.width),
+                        int(line.y1 * line.page.height),
+                    )
+                    for line in doc.text_boxes
+                ],
+                word_labels=range(len(doc.text_boxes)),
+                return_attention_mask=True,
+            )
+            if self.use_image:
+                prep.update(self.image_processor(images=page.image))
+
+            # Compute line offsets into layoutlm generated tokens
+            line_indices = prep["labels"][:-1]
+            line_starts = [
+                i
+                for i, curr_index in enumerate(line_indices)
+                if curr_index != -100 and curr_index != line_indices[i - 1]
+            ]
+
+            res["input_ids"].append(prep["input_ids"])
+            res["bbox"].append(prep["bbox"])
+            res["line_starts"].append(line_starts)
+            if self.use_image:
+                res["pixel_values"].append(prep["pixel_values"][0])
+
+        return res
+
+    def collate(self, batch, device):
+        # Flatten most of these arrays to process batches page per page and
+        # not sample per sample
+
+        offset = 0
+        window_max_size = 0
+        window_count = 0
+        windows_per_page = []
+        for sample_input_ids in batch["input_ids"]:
+            for page_input_ids in sample_input_ids:
+                # fmt: off
+                windows_per_page.append([
+                    [
+                        offset + 0,
+                        *range(1 + offset + window_i * self.stride,
+                               1 + offset + min(window_i * self.stride + self.window, len(page_input_ids) - 2)),  # noqa: E501
+                        offset + len(page_input_ids) - 1,
+                    ]
+                    for window_i in range(0, 1 + max(0, math.ceil((len(page_input_ids) - 2 - self.window) / self.stride)))  # noqa: E501
+                ])
+                # fmt: on
+                offset += len(page_input_ids)
+                window_max_size = max(
+                    window_max_size, max(map(len, windows_per_page[-1]))
+                )
+                window_count += len(windows_per_page[-1])
+
+        windows = as_folded_tensor(
+            windows_per_page,
+            full_names=("page", "window", "token"),
+            data_dims=("window", "token"),
+            dtype=torch.long,
+        )
+        indexer = torch.zeros(windows.max() + 1, dtype=torch.long)
+
+        # Sort each occurrence of an initial token by its contextualization score:
+        # We can only use the amax reduction, so to retrieve the best occurrence, we
+        # insert the index of the token output by the transformer inside the score
+        # using a lexicographic approach
+        # (score + index / n_tokens) ~ (score * n_tokens + index), taking the max,
+        # and then retrieving the index of the token using the modulo operator.
+        scores = compute_contextualization_scores(windows)
+        scores = scores * len(scores) + torch.arange(len(scores))
+        indexer.index_reduce_(
+            dim=0,
+            source=scores,
+            index=windows.view(-1),
+            reduce="amax",
+        )
+        indexer %= len(scores)
+
+        # Get token indices for each line -> sample, page, line, token
+        line_window_indices = []
+        line_window_offsets_flat = [0]
+        offset = 0
+        for sample_input_ids, sample_line_starts in zip(
+            batch["input_ids"], batch["line_starts"]
+        ):
+            sample_line_window_indices = []
+            line_window_indices.append(sample_line_window_indices)
+            for page_line_starts, page_input_ids in zip(
+                sample_line_starts, sample_input_ids
+            ):
+                page_line_window_indices = []
+                sample_line_window_indices.append(page_line_window_indices)
+                for line_start, line_end in zip(
+                    page_line_starts, (*page_line_starts[1:], len(page_input_ids))
+                ):
+                    line_window_offsets_flat.append(
+                        line_window_offsets_flat[-1] + line_end - line_start
+                    )
+                    page_line_window_indices.append(
+                        list(range(offset + line_start, offset + line_end))
+                    )
+                offset += len(page_input_ids)
+        line_window_indices = as_folded_tensor(
+            line_window_indices,
+            full_names=("sample", "page", "line", "token"),
+            data_dims=("token",),
+            dtype=torch.long,
+        )
+        line_window_offsets_flat = as_folded_tensor(
+            # discard the last offset, since we start from 0 and add each line length
+            data=torch.as_tensor(line_window_offsets_flat[:-1]),
+            data_dims=("line",),
+            full_names=("sample", "page", "line"),
+            lengths=line_window_indices.lengths[:-1],
+        )
+
+        kw = dict(
+            full_names=("sample", "page", "subword"),
+            data_dims=("subword",),
+            device=device,
+        )
+        collated = {
+            "input_ids": as_folded_tensor(batch["input_ids"], **kw, dtype=torch.long),
+            "bbox": as_folded_tensor(batch["bbox"], **kw, dtype=torch.long),
+            "windows": windows,
+            "indexer": indexer[line_window_indices],
+            "line_window_indices": indexer[line_window_indices].as_tensor(),
+            "line_window_offsets_flat": line_window_offsets_flat,
+        }
+        if self.use_image:
+            collated["pixel_values"] = torch.stack(
+                [
+                    torch.as_tensor(x, device=device)
+                    for x in as_folded_tensor(
+                        batch["pixel_values"], **kw, dtype=torch.long
+                    )
+                ],
+                dim=0,
+            )
+        return collated
+
+    def forward(self, batch):
+        token_embeddings = self.hf_model.forward(
+            input_ids=batch["input_ids"].as_tensor()[batch["windows"]],
+            bbox=batch["bbox"].as_tensor()[batch["windows"]],
+            attention_mask=batch["windows"].mask,
+        ).last_hidden_state
+        line_embedding = torch.nn.functional.embedding_bag(
+            input=batch["line_window_indices"],
+            weight=token_embeddings.view(-1, token_embeddings.size(-1)),
+            offsets=batch["line_window_offsets_flat"],
+            mode=self.line_pooling,
+        )
+        return {"embeddings": line_embedding}

--- a/edspdf/pipes/embeddings/simple_text_embedding.py
+++ b/edspdf/pipes/embeddings/simple_text_embedding.py
@@ -209,7 +209,8 @@ class SimpleTextEmbedding(TrainablePipe[EmbeddingOutput]):
                 words = [m.group(0) for m in self.word_regex.finditer(b.text)]
 
                 for word in words:
-                    ascii_str = anyascii(word)
+                    # ascii_str = unidecode.unidecode(word)
+                    ascii_str = anyascii(word).strip()
                     tokens_shape[-1][i].append(
                         self.shape_voc.encode(word_shape(ascii_str))
                     )
@@ -253,7 +254,7 @@ class SimpleTextEmbedding(TrainablePipe[EmbeddingOutput]):
             self.shape_embedding(batch["tokens_shape"].as_tensor())
             + self.prefix_embedding(batch["tokens_prefix"].as_tensor())
             + self.suffix_embedding(batch["tokens_suffix"].as_tensor())
-            + self.norm_embedding(batch["tokens_norm"].as_tensor())
+            # + self.norm_embedding(batch["tokens_norm"].as_tensor())
         )
 
         return {"embeddings": batch["tokens_shape"].with_data(text_embeds)}

--- a/edspdf/pipes/embeddings/simple_text_embedding.py
+++ b/edspdf/pipes/embeddings/simple_text_embedding.py
@@ -5,6 +5,7 @@ from typing import Set
 
 import regex
 import torch
+from anyascii import anyascii
 from foldedtensor import FoldedTensor, as_folded_tensor
 from typing_extensions import TypedDict
 
@@ -208,8 +209,7 @@ class SimpleTextEmbedding(TrainablePipe[EmbeddingOutput]):
                 words = [m.group(0) for m in self.word_regex.finditer(b.text)]
 
                 for word in words:
-                    # ascii_str = unidecode(word)
-                    ascii_str = word
+                    ascii_str = anyascii(word)
                     tokens_shape[-1][i].append(
                         self.shape_voc.encode(word_shape(ascii_str))
                     )

--- a/edspdf/pipes/embeddings/sub_box_cnn_pooler.py
+++ b/edspdf/pipes/embeddings/sub_box_cnn_pooler.py
@@ -98,10 +98,12 @@ class SubBoxCNNPooler(TrainablePipe[EmbeddingOutput]):
             dim=2,
         )
         pooled = box_token_embeddings.max(1).values
+        pooled = self.linear(pooled)
+        # print("TEXT EMBEDS", pooled.shape, pooled.sum())
 
         return {
             "embeddings": as_folded_tensor(
-                data=self.linear(pooled),
+                data=pooled,
                 lengths=embeddings.lengths[:-1],  # pooled on the last dim
                 data_dims=["line"],  # fully flattened
                 full_names=["sample", "page", "line"],

--- a/edspdf/structures.py
+++ b/edspdf/structures.py
@@ -89,6 +89,7 @@ class PDFDoc(BaseModel):
 
     content: bytes = attrs.field(repr=lambda c: f"{len(c)} bytes")
     id: str = None
+    num_pages: int = 0
     pages: List["Page"] = attrs.field(factory=list)
     error: bool = False
     content_boxes: List[Union["TextBox"]] = attrs.field(factory=list)

--- a/edspdf/structures.py
+++ b/edspdf/structures.py
@@ -201,7 +201,7 @@ class Box(BaseModel):
 
     @property
     def page(self):
-        return self.doc.pages[self.page_num]
+        return next(p for p in self.doc.pages if p.page_num == self.page_num)
 
     def __lt__(self, other):
         self_page_num = self.page_num or 0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
         - pipes/embeddings/sub-box-cnn-pooler.md
         - pipes/embeddings/box-layout-embedding.md
         - pipes/embeddings/box-transformer.md
+        - pipes/embeddings/huggingface-embedding.md
       - Extractors:
         - pipes/extractors/index.md
         - pipes/extractors/pdfminer.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "coverage>=6.5.0",
     "datasets~=2.10",
     "huggingface_hub>=0.8.1",
+    "transformers~=4.30",
 ]
 docs = [
     "mike~=1.1.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,12 +49,12 @@ dev = [
 docs = [
     "mike~=1.1.2",
     "mkdocs@git+https://github.com/mkdocs/mkdocs.git@5af8bd30538ff8f0cfb698c8b90c3020da319f92",
-    "mkdocstrings==0.20.0",
+    "mkdocstrings~=0.20",
+    "mkdocstrings-python~=1.1",
     "mkdocs-autorefs@git+https://github.com/percevalw/mkdocs-autorefs.git@0.4.1.post0",
     "mkdocs-gen-files~=0.4.0",
     "mkdocs-literate-nav~=0.6.0",
     "mkdocs-material~=9.1.0",
-    "mkdocstrings-python~=0.8.3",
     "mkdocs-glightbox~=0.3.1",
     "pybtex~=0.24.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ docs = [
 "box-preprocessor" = "edspdf.pipes.embeddings.box_layout_preprocessor:BoxLayoutPreprocessor"
 
 # Embeddings
+"huggingface-embedding" = "edspdf.pipes.embeddings.huggingface_embedding:HuggingfaceEmbedding"
 "simple-text-embedding" = "edspdf.pipes.embeddings.simple_text_embedding:SimpleTextEmbedding"
 "sub-box-cnn-pooler" = "edspdf.pipes.embeddings.sub_box_cnn_pooler:SubBoxCNNPooler"
 "embedding-combiner" = "edspdf.pipes.embeddings.embedding_combiner:EmbeddingCombiner"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ dependencies = [
     "pdfminer.six>=20220319",
     "pypdfium2~=2.7",
     "rich-logger>=0.3.0,<1.0.0",
-    "safetensors~=0.3.1"
+    "safetensors~=0.3.1",
+    "anyascii>=0.3.2",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,13 @@ dynamic = ["version"]
 requires-python = ">3.7.6,<4.0,!=3.8.1"
 
 dependencies = [
+    "anyascii>=0.3.2",
     "scikit-learn>=1.0.2,<2.0.0",
     "pydantic>=1.2,<2.0.0",
     "catalogue~=2.0",
     "networkx~=2.6",
     "confit>=0.2.1,<1.0.0",
-    "foldedtensor>=0.2.1,<1.0.0",
+    "foldedtensor>=0.3.0,<1.0.0",
     "torch>1.0.0",
     "accelerate>=0.12.0,<1.0.0",
     "tqdm~=4.64.1",

--- a/tests/core/config.cfg
+++ b/tests/core/config.cfg
@@ -11,7 +11,6 @@ components = ${components}
 [components.classifier]
 @factory = "trainable-classifier"
 labels = []
-activation = "relu"
 
 [components.classifier.embedding]
 @factory = "box-transformer"

--- a/tests/recipes/config.cfg
+++ b/tests/recipes/config.cfg
@@ -34,7 +34,6 @@ n_layers = 1
 [components.classifier]
 @factory = "trainable-classifier"
 labels = []
-activation = "relu"
 embedding = ${components.embedding}
 
 [components.embedding.embedding]

--- a/tests/recipes/test_train.py
+++ b/tests/recipes/test_train.py
@@ -230,7 +230,6 @@ def test_function(pdf, error_pdf, change_test_dir, dummy_dataset, tmp_path):
         config={
             "embedding": model.get_pipe("embedding"),
             "labels": [],
-            "activation": "relu",
         },
     )
     print(model.config.to_str())
@@ -299,7 +298,6 @@ def test_function_huggingface(pdf, error_pdf, change_test_dir, dummy_dataset, tm
         config={
             "embedding": model.get_pipe("embedding"),
             "labels": [],
-            "activation": "relu",
         },
     )
     trf = model.get_pipe("embedding")


### PR DESCRIPTION
## Description

This PR introduces a new `HuggingfaceEmbedding` component, which wraps Huggingface models (such as LayoutLM or LILT). Compared with using the raw huggingface model, this wrapper offers a simple mechanism for splitting long documents into sliding windows before sending them to the model (since the maximum number of tokens sent to the transformer is capped at 512, and sending entire sequences all at once can be memory-intensive). 

## Example

Here is an example of how to define a pipeline with the HuggingfaceEmbedding component:

```python
from edspdf import Pipeline

pipeline = Pipeline()
pipeline.add_pipe("pdfminer-extractor", name="extractor")
pipeline.add_pipe(
    "huggingface-embedding",
    name="embedding",
    config={
        "model": "microsoft/layoutlmv3-base",
        "use_image": False,
        "window": 128,
        "stride": 64,
        "line_pooling": "mean",
    },
)
model.add_pipe(
    "trainable-classifier",
    name="classifier",
    config={
        "embedding": model.get_pipe("embedding"),
        "labels": [],
    },
)
```

This model can then be trained following the [training recipe](https://aphp.github.io/edspdf/latest/recipes/training/).

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [ ] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
