### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.8.0
 
 ### Added
 

--- a/edspdf/__init__.py
+++ b/edspdf/__init__.py
@@ -6,4 +6,4 @@ from .structures import Box, Page, PDFDoc, Text, TextBox, TextProperties
 
 from . import utils  # isort:skip
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "catalogue~=2.0",
     "networkx~=2.6",
     "confit>=0.4.3,<1.0.0",
-    "foldedtensor>=0.3.0,<1.0.0",
+    "foldedtensor>=0.3.1,<1.0.0",
     "torch>1.0.0",
     "accelerate>=0.12.0,<1.0.0",
     "tqdm~=4.64.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

### Added

- Add multi-modal transformers (`huggingface-embedding`) with windowing options
- Add `render_page` option to `pdfminer` extractor, for multi-modal PDF features
- Add inference utilities (`accelerators`), with simple mono process support and multi gpu / cpu support
- Packaging utils (`pipeline.package(...)`) to make a pip installable package from a pipeline

### Changed

- Updated API to follow EDS-NLP's refactoring
- Updated `confit` to 0.4.2 (better errors) and `foldedtensor` to 0.3.0 (better multiprocess support)
- Removed `pipeline.score`. You should use `pipeline.pipe`, a custom scorer and `pipeline.select_pipes` instead.
- Better test coverage

### Fixed

- Fixed `attrs` dependency only being installed in dev mode

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
