### PR TITLE
feat: switch to hatch package manager

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -15,9 +15,8 @@ jobs:
       - name: Set PY variable
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
 
-      - name: Install dependencies
-        run: |
-          pip install -e '.[docs]'
+      - name: Install hatch
+        run: pip install hatch
 
       - name: Set up Git
         run: |
@@ -26,5 +25,5 @@ jobs:
       - name: Build documentation
         run: |
           git fetch origin gh-pages
-          mike delete main
-          mike deploy --push main
+          hatch -e docs run mike delete main
+          hatch -e docs run mike deploy --push main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Upload Python Package
+name: Release
 
 on:
   workflow_dispatch:
@@ -14,6 +14,34 @@ on:
     types: [published]
 
 jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}/${{ matrix.arch || '*' }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            arch: x86_64
+          - os: macos-latest
+            arch: arm64
+          - os: ubuntu-latest
+            arch: '*'  # unused
+          - os: windows-latest
+            arch: '*'  # unused
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.13.1
+        env:
+          CIBW_ARCHS_MACOS: ${{ matrix.arch }}
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
@@ -23,28 +51,28 @@ jobs:
       - name: Build sdist
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
 
-  PyPI:
+  pypi:
     name: Upload to PyPI
-
-    needs: [build_sdist]
+    needs: [ build_wheels, build_sdist ]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
-    - uses: actions/download-artifact@v2
-      with:
-        name: artifact
-        path: dist
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@v1.5.0
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1
 
-  Documentation:
+  documentation:
+    name: Build documentation
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -53,8 +81,8 @@ jobs:
       - name: Set PY variable
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
 
-      - name: Install dependencies
-        run: pip install -e '.[docs]'
+      - name: Install hatch
+        run: pip install hatch
 
       - name: Set up Git
         run: |
@@ -64,4 +92,4 @@ jobs:
       - name: Build documentation
         run: |
           git fetch origin gh-pages
-          mike deploy --push --no-redirect --update-aliases $GITHUB_REF_NAME latest
+          hatch -e docs run mike deploy --push --no-redirect --update-aliases $GITHUB_REF_NAME latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,16 +31,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
 
-      - name: Set PY variable
-        run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-
-      - name: Install dependencies
-        run: |
-          pip install -e '.[dev]'
-          pip install poetry build
+      - name: Install hatch
+        run: pip install hatch
 
       - name: Test with Pytest on Python ${{ matrix.python-version }}
-        run: python -m pytest --cov edspdf --cov-report xml
+        run: hatch run tests
 
       - name: Upload coverage
         uses: codecov/codecov-action@v2
@@ -54,16 +49,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Set PY variable
-        run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-
-      - name: Install dependencies
-        run: |
-          pip install -e '.[docs]'
+      - name: Install hatch
+        run: pip install hatch
 
       - name: Build documentation
-        run: |
-          mkdocs build --clean
+        run: hatch run docs:build
 
   Installation:
     runs-on: ubuntu-latest
@@ -76,6 +66,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install library
+      - name: Install library from source
         run: |
           pip install .

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
 - Updated `confit` to 0.4.2 (better errors) and `foldedtensor` to 0.3.0 (better multiprocess support)
 - Removed `pipeline.score`. You should use `pipeline.pipe`, a custom scorer and `pipeline.select_pipes` instead.
 - Better test coverage
+- Use `hatch` instead of `setuptools` to build the package / docs and run the tests
 
 ### Fixed
 

--- a/contributing.md
+++ b/contributing.md
@@ -8,7 +8,7 @@ We welcome contributions ! There are many ways to help. For example, you can:
 
 ## Development installation
 
-To be able to run the test suite and develop your own pipeline, you should clone the repo and install it locally.
+To be able to run the test suite and develop your own pipeline, you should clone the repo and install it locally. We use the [`hatch`](https://hatch.pypa.io/) package manager to manage the project.
 
 
 <div class="termy">
@@ -18,13 +18,15 @@ color:gray # Clone the repository and change directory
 $ git clone ssh://git@github.com/aphp/edspdf.git
 ---> 100%
 
+color:gray # Ensure hatch is installed, preferably via pipx
+$ pipx install hatch
+
 $ cd edspdf
 
-color:gray # Create and activate a virtual environment for build isolation
-$ python -m venv .venv
-$ source .venv/bin/activate
-color:gray # Install the dependencies
-$ pip install '.[dev]'
+color:gray # Enter a shell to develop / test the project. This will install everything required in a virtual environment. You can also `source` the path shown by hatch.
+$ hatch shell
+$ ...
+$ exit  # when you're done
 ```
 
 </div>
@@ -89,13 +91,13 @@ Most modern editors propose extensions that will format files on save.
 Make sure to document your improvements, both within the code with comprehensive docstrings,
 as well as in the documentation itself if need be.
 
-We use `MkDocs` for EDS-PDF's documentation. You can checkout the changes you make with:
+We use `MkDocs` for EDS-PDF's documentation. You can view your changes with
 
 <div class="termy">
 
 ```console
 color:gray # Run the documentation
-$ mkdocs serve
+$ hatch run docs:serve
 ```
 
 </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,11 @@ dependencies = [
     "loguru",
 ]
 
-[project.optional-dependencies]
-dev = [
+
+[tool.hatch.envs.default]
+dependencies = [
+    "pip",
+    "poetry",
     "pandas>=1.2,<2.0.0",
     "black==22.6.0",
     "flake8>=3.0",
@@ -51,7 +54,12 @@ dev = [
     "huggingface_hub>=0.8.1",
     "transformers~=4.30",
 ]
-docs = [
+
+[tool.hatch.envs.default.scripts]
+tests = "pytest --cov=edspdf --cov-report=term-missing --cov-report=xml"
+
+[tool.hatch.envs.docs]
+dependencies = [
     "mike~=1.1.2",
     "mkdocs@git+https://github.com/mkdocs/mkdocs.git@5af8bd30538ff8f0cfb698c8b90c3020da319f92",
     "mkdocstrings~=0.20",
@@ -65,6 +73,12 @@ docs = [
     "pybtex~=0.24.0",
 ]
 
+[tool.hatch.envs.docs.scripts]
+build = "mkdocs build --site-dir public --clean"
+serve = "mkdocs serve"
+
+[tool.hatch.version]
+path = "edspdf/__init__.py"
 
 [project.entry-points."edspdf_factories"]
 # Extractors
@@ -99,12 +113,6 @@ docs = [
 [project.entry-points."mkdocs.plugins"]
 
 "bibtex" = "docs.scripts.bibtex:BibTexPlugin"
-
-[tool.setuptools.dynamic]
-version = { attr = "edspdf.__version__" }
-
-[tool.setuptools.packages.find]
-where = ["."]
 
 [tool.interrogate]
 ignore-init-method = true
@@ -179,10 +187,9 @@ select = [
 fixable = ["E", "F", "W", "I"]
 
 [tool.ruff.isort]
-known-first-party = ["edspdf"]
-known-third-party = ["build"]
-
+    known-first-party = ["edspdf"]
+    known-third-party = ["build"]
 
 [build-system]
-requires = ["setuptools", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/tests/utils/test_package.py
+++ b/tests/utils/test_package.py
@@ -1,7 +1,9 @@
 import importlib
+import subprocess
+import sys
 
-import pip
 import pytest
+import torch
 
 from edspdf.utils.package import package
 
@@ -58,8 +60,10 @@ authors = ["Test Author <test.author@mail.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-torch = "^1.4.0"
-"""
+torch = "^{}"
+""".format(
+            torch.__version__.split("+")[0]
+        )
     )
 
     with pytest.raises(ValueError):
@@ -95,12 +99,18 @@ torch = "^1.4.0"
     assert (tmp_path / "pyproject.toml").is_file()
 
     # pip install the whl file
-    pip.main(
-        [
-            "install",
-            str(tmp_path / "dist" / f"{module_name}-0.1.0-py3-none-any.whl"),
-            "--force-reinstall",
-        ]
+    print(
+        subprocess.check_output(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                str(tmp_path / "dist" / f"{module_name}-0.1.0-py3-none-any.whl"),
+                "--force-reinstall",
+            ],
+            stderr=subprocess.STDOUT,
+        )
     )
 
     module = importlib.import_module(module_name)
@@ -138,5 +148,30 @@ def load(device: "torch.device" = "cpu") -> edspdf.Pipeline:
 def clean_after():
     yield
 
-    pip.main(["uninstall", "-y", "test-model"])
-    pip.main(["uninstall", "-y", "my-test-model"])
+    print(
+        subprocess.check_output(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "uninstall",
+                "-y",
+                "test-model",
+            ],
+            stderr=subprocess.STDOUT,
+        )
+    )
+
+    print(
+        subprocess.check_output(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "uninstall",
+                "-y",
+                "my-test-model",
+            ],
+            stderr=subprocess.STDOUT,
+        )
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Setuptools is not the right fit for our project:
- with need to have different environments to test / build the docs / ...
- we want to support `pip install -e .`
- we want a PEP 621 compatible pyproject.toml if possible

Hatch supports all of this, poetry & setuptools don't.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
