### PR TITLE
v0.8.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.8.1
+
+### Fixed
+
+- Fix typing to allow passing an accelerator dict to `Pipeline.pipe(...)`
+- Removed multiprocessing accelerator debug output
+- Fixed absolute links in github-pages docs (e.g. image assets)
+
+### Changed
+
+- Added auto-links to components in the docs (by comparing span contents with entry points)
+
 ## v0.8.0
 
 ### Added

--- a/docs/data-structures.md
+++ b/docs/data-structures.md
@@ -17,11 +17,11 @@ When running a trainable component, the [PDFDoc][edspdf.structures.PDFDoc] is pr
 
 ## Data models
 
-The main data structure is the [[PDFDoc][edspdf.structures.PDFDoc]][edspdf.structures.PDFDoc], which represents full a PDF document. It contains the raw PDF content, annotations for the full document, regardless of pages. A PDF is split into [`Page`][edspdf.structures.Page] objects that stores their number, dimension and optionally an image of the rendered page.
+The main data structure is the [PDFDoc][edspdf.structures.PDFDoc], which represents full a PDF document. It contains the raw PDF content, annotations for the full document, regardless of pages. A PDF is split into [Page][edspdf.structures.Page] objects that stores their number, dimension and optionally an image of the rendered page.
 
-The PDF annotations are stored in [`Box`][edspdf.structures.Box] objects, which represent a rectangular region of the PDF. At the moment, box can only be specialized into [`TextBox`][edspdf.structures.TextBox] to represent text regions, such as lines extracted by a PDF extractor. Aggregated texts are stored in [`Text`][edspdf.structures.Text] objects, that are not associated with a specific box.
+The PDF annotations are stored in [Box][edspdf.structures.Box] objects, which represent a rectangular region of the PDF. At the moment, box can only be specialized into [TextBox][edspdf.structures.TextBox] to represent text regions, such as lines extracted by a PDF extractor. Aggregated texts are stored in [Text][edspdf.structures.Text] objects, that are not associated with a specific box.
 
-A [`TextBox`][edspdf.structures.TextBox] contains a list of [`TextProperties`][edspdf.structures.TextProperties] objects to store the style properties of a styled spans of the text.
+A [TextBox][edspdf.structures.TextBox] contains a list of [TextProperties][edspdf.structures.TextProperties] objects to store the style properties of a styled spans of the text.
 
 ??? note "Reference"
 

--- a/docs/recipes/rule-based.md
+++ b/docs/recipes/rule-based.md
@@ -30,7 +30,7 @@ y1 = 0.6
 threshold = 0.1
 
 [components.aggregator]
-@factory = "styled-aggregator"  # (4)
+@factory = "simple-aggregator"  # (4)
 ```
 
 1. This is the top-level object, which organises the entire extraction process.

--- a/docs/scripts/plugin.py
+++ b/docs/scripts/plugin.py
@@ -1,37 +1,32 @@
 import os
-import shutil
 from pathlib import Path
 
-import mkdocs
+import mkdocs.config
+import mkdocs.plugins
+import mkdocs.structure
+import mkdocs.structure.files
+import mkdocs.structure.nav
+import mkdocs.structure.pages
+
+try:
+    from importlib.metadata import entry_points
+except ImportError:
+    from importlib_metadata import entry_points
+
+
+def exclude_file(name):
+    return name.startswith("assets/fragments/")
+
 
 # Add the files from the project root
 
-# Generate the code reference pages and navigation.
-doc_reference = Path("docs/reference")
-shutil.rmtree(doc_reference, ignore_errors=True)
-os.makedirs(doc_reference, exist_ok=True)
-root = Path("edspdf")
-for path in sorted(root.rglob("*.py")):
-    if "poppler_src" in str(path):
-        continue
-    module_path = path.relative_to(root.parent).with_suffix("")
-    doc_path = path.relative_to(root.parent).with_suffix(".md")
-    full_doc_path = doc_reference / doc_path
-    parts = list(module_path.parts)
-    if parts[-1] == "__init__":
-        parts = parts[:-1]
-        doc_path = doc_path.with_name("index.md")
-        full_doc_path = full_doc_path.with_name("index.md")
-    elif parts[-1] == "__main__":
-        continue
-    ident = ".".join(parts)
-    os.makedirs(full_doc_path.parent, exist_ok=True)
-    with open(full_doc_path, "w") as fd:
-        print(f"# `{ident}`\n", file=fd)
-        print("::: " + ident, file=fd)
-        if root != "edspdf":
-            print("    options:", file=fd)
-            print("        show_source: false", file=fd)
+VIRTUAL_FILES = {}
+REFERENCE_TEMPLATE = """
+# `{ident}`
+::: {ident}
+    options:
+        show_source: false
+"""
 
 
 def on_files(files: mkdocs.structure.files.Files, config: mkdocs.config.Config):
@@ -48,45 +43,205 @@ def on_files(files: mkdocs.structure.files.Files, config: mkdocs.config.Config):
         Additional arguments
     """
 
-    def get_nested_files(path):
-        files = []
-        for file in path.iterdir():
-            if file.is_dir():
-                index = file / "index.md"
-                if index.exists():
-                    # Get name from h1 heading in index
-                    name = index.read_text().split("\n")[0].strip("# ")
-                    if name.startswith("`edspdf"):
-                        name = name[1:-1].split(".")[-1]
-                    files.append({name: get_nested_files(file)})
-                else:
-                    title = file.name.replace("_", " ").replace("-", " ").title()
-                    files.append({title: get_nested_files(file)})
-            else:
-                name = file.read_text().split("\n")[0].strip("# ")
-                if name.startswith("`edspdf"):
-                    name = name[1:-1].split(".")[-1]
-                    files.append({name: str(file.relative_to(config["docs_dir"]))})
-                else:
-                    files.append(str(file.relative_to(config["docs_dir"])))
-        return files
-
-    def rec(tree):
-        if isinstance(tree, list):
-            return [rec(item) for item in tree]
-        elif isinstance(tree, dict):
-            return {k: rec(item) for k, item in tree.items()}
-        elif isinstance(tree, str):
-            if tree.endswith("/"):
-                # We have a directory
-                path = Path(config["docs_dir"]) / tree
-                if path.is_dir():
-                    return get_nested_files(path)
-                else:
-                    return tree
-            else:
-                return tree
+    root = Path("edspdf")
+    reference_nav = []
+    for path in sorted(root.rglob("*.py")):
+        module_path = path.relative_to(root.parent).with_suffix("")
+        doc_path = Path("reference") / path.relative_to(root.parent).with_suffix(".md")
+        # full_doc_path = Path("docs/reference/") / doc_path
+        parts = list(module_path.parts)
+        current = reference_nav
+        for part in parts[:-1]:
+            sub = next((item[part] for item in current if part in item), None)
+            if sub is None:
+                current.append({part: []})
+                sub = current[-1][part]
+            current = sub
+        if parts[-1] == "__init__":
+            parts = parts[:-1]
+            doc_path = doc_path.with_name("index.md")
+            current.append({"index.md": str(doc_path)})
+        elif parts[-1] == "__main__":
+            continue
         else:
-            return tree
+            current.append({parts[-1]: str(doc_path)})
+        ident = ".".join(parts)
+        os.makedirs(doc_path.parent, exist_ok=True)
+        VIRTUAL_FILES[str(doc_path)] = REFERENCE_TEMPLATE.format(ident=ident)
 
-    config["nav"] = rec(config["nav"])
+    for item in config["nav"]:
+        if not isinstance(item, dict):
+            continue
+        key = next(iter(item.keys()))
+        if not isinstance(item[key], str):
+            continue
+        if item[key].strip("/") == "reference":
+            item[key] = reference_nav
+
+    VIRTUAL_FILES["contributing.md"] = Path("contributing.md").read_text()
+    VIRTUAL_FILES["changelog.md"] = Path("changelog.md").read_text()
+
+    return mkdocs.structure.files.Files(
+        [file for file in files if not exclude_file(file.src_path)]
+        + [
+            mkdocs.structure.files.File(
+                file,
+                config["docs_dir"],
+                config["site_dir"],
+                config["use_directory_urls"],
+            )
+            for file in VIRTUAL_FILES
+        ]
+    )
+
+
+def on_nav(nav, config, files):
+    def rec(node):
+        if isinstance(node, list):
+            return [rec(item) for item in node]
+        if node.is_section and node.title == "Code Reference":
+            return
+        if isinstance(node, mkdocs.structure.nav.Navigation):
+            return rec(node.items)
+        if isinstance(node, mkdocs.structure.nav.Section):
+            if (
+                len(node.children)
+                and node.children[0].is_page
+                and node.children[0].is_index
+            ):
+                first = node.children[0]
+                link = mkdocs.structure.nav.Link(
+                    title=first.title,
+                    url=first.url,
+                )
+                link.is_index = True
+                first.title = "Overview"
+                node.children.insert(0, link)
+            return rec(node.children)
+
+    rec(nav.items)
+
+
+def on_page_read_source(page, config):
+    if page.file.src_path in VIRTUAL_FILES:
+        return VIRTUAL_FILES[page.file.src_path]
+    return None
+
+
+HREF_REGEX = r'href=(?:"([^"]*)"|\'([^\']*)|[ ]*([^ =>]*)(?![a-z]+=))'
+# Maybe find something less specific ?
+PIPE_REGEX = r"(?<=[^a-zA-Z0-9._-])eds[.][a-zA-Z0-9._-]*(?=[^a-zA-Z0-9._-])"
+
+
+@mkdocs.plugins.event_priority(-1000)
+def on_post_page(
+    output: str,
+    page: mkdocs.structure.pages.Page,
+    config: mkdocs.config.Config,
+):
+    """
+    1. Replace absolute paths with path relative to the rendered page
+       This must be performed after all other plugins have run.
+    2. Replace component names with links to the component reference
+
+    Parameters
+    ----------
+    output
+    page
+    config
+
+    Returns
+    -------
+
+    """
+
+    autorefs = config["plugins"]["autorefs"]
+    edspdf_factories_entry_points = {
+        ep.name: ep.value for ep in entry_points()["edspdf_factories"]
+    }
+
+    def get_component_url(name):
+        ep = edspdf_factories_entry_points.get(name)
+        if ep is None:
+            return None
+        try:
+            url = autorefs.get_item_url(ep.replace(":", "."))
+        except KeyError:
+            pass
+        else:
+            return url
+        return None
+
+    def get_relative_link(url):
+        page_url = os.path.join("/", page.file.url)
+        if url.startswith("/"):
+            url = os.path.relpath(url, page_url)
+        return url
+
+    def replace_component_span(span):
+        content = span.text
+        if content is None:
+            return
+        link_url = get_component_url(content.strip("\"'"))
+        if link_url is None:
+            return
+        a = lh.Element("a", href="/" + link_url)
+        a.text = content
+        span.text = ""
+        span.append(a)
+
+    def replace_component_names(root):
+        # Iterate through all span elements
+        spans = list(root.iter("span", "code"))
+        for i, span in enumerate(spans):
+            prev = span.getprevious()
+            if span.getparent().tag == "a":
+                continue
+            # To avoid replacing default component name in parameter tables
+            if prev is None or prev.text != "DEFAULT:":
+                replace_component_span(span)
+            # if span.text == "add_pipe":
+            #     next_span = span.getnext()
+            #     if next_span is None:
+            #         continue
+            #     next_span = next_span.getnext()
+            #     if next_span is None or next_span.tag != "span":
+            #         continue
+            #     replace_component_span(next_span)
+            #     continue
+            # tokens = ["@", "factory", "="]
+            # while True:
+            #     if len(tokens) == 0:
+            #         break
+            #     if span.text != tokens[0]:
+            #         break
+            #     tokens = tokens[1:]
+            #     span = span.getnext()
+            #     while span is not None and (
+            #       span.text is None or not span.text.strip()
+            #     ):
+            #         span = span.getnext()
+            # if len(tokens) == 0:
+            #     replace_component_span(span)
+
+        # Convert the modified tree back to a string
+        return root
+
+    def replace_absolute_links(root):
+        # Iterate through all a elements
+        for a in root.iter("a"):
+            href = a.get("href")
+            if href is None or href.startswith("http"):
+                continue
+            a.set("href", get_relative_link(href))
+
+        # Convert the modified tree back to a string
+        return root
+
+    # Replace absolute paths with path relative to the rendered page
+    import lxml.html as lh
+
+    root = lh.fromstring(output)
+    root = replace_component_names(root)
+    root = replace_absolute_links(root)
+    return "".join(lh.tostring(e, encoding="unicode") for e in root)

--- a/edspdf/__init__.py
+++ b/edspdf/__init__.py
@@ -6,4 +6,4 @@ from .structures import Box, Page, PDFDoc, Text, TextBox, TextProperties
 
 from . import utils  # isort:skip
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/edspdf/accelerators/multiprocessing.py
+++ b/edspdf/accelerators/multiprocessing.py
@@ -12,7 +12,7 @@ from ..registry import registry
 from ..utils.collections import batchify
 from .base import Accelerator, FromDictFieldsToDoc, FromDoc, ToDoc
 
-DEBUG = True
+DEBUG = False
 
 debug = (
     (lambda *args, flush=False, **kwargs: print(*args, **kwargs, flush=True))

--- a/edspdf/pipeline.py
+++ b/edspdf/pipeline.py
@@ -22,10 +22,11 @@ from typing import (
     Union,
 )
 
-from confit import Config, validate_arguments
+from confit import Config
 from confit.errors import ConfitValidationError, patch_errors
 from confit.utils.collections import join_path, split_path
 from confit.utils.xjson import Reference
+from pydantic import parse_obj_as
 from typing_extensions import Literal
 
 import edspdf
@@ -262,7 +263,6 @@ class Pipeline:
 
         return doc
 
-    @validate_arguments
     def pipe(
         self,
         inputs: Any,
@@ -303,7 +303,7 @@ class Pipeline:
             batch_size = self.batch_size
 
         if accelerator is None:
-            accelerator = {"@accelerator": "simple", "batch_size": batch_size}
+            accelerator = "simple"
         if isinstance(accelerator, str):
             accelerator = {"@accelerator": accelerator, "batch_size": batch_size}
         if isinstance(accelerator, dict):
@@ -312,8 +312,8 @@ class Pipeline:
         kwargs = {
             "inputs": inputs,
             "model": self,
-            "to_doc": to_doc,
-            "from_doc": from_doc,
+            "to_doc": parse_obj_as(Optional[ToDoc], to_doc),
+            "from_doc": parse_obj_as(Optional[FromDoc], from_doc),
         }
         for k, v in list(kwargs.items()):
             if v is None:

--- a/edspdf/pipes/classifiers/dummy.py
+++ b/edspdf/pipes/classifiers/dummy.py
@@ -6,7 +6,7 @@ from edspdf.structures import PDFDoc
 @registry.factory.register("dummy-classifier")
 class DummyClassifier:
     """
-    Dummy classifier, for chaos purposes. Classifies each line to a random element.
+    Dummy classifier. Classifies each line to the same element.
 
     Parameters
     ----------

--- a/edspdf/pipes/classifiers/trainable.py
+++ b/edspdf/pipes/classifiers/trainable.py
@@ -32,14 +32,12 @@ class TrainableClassifier(TrainablePipe[Dict[str, Any]]):
 
     The classifier is composed of the following blocks:
 
-    - a configurable box embedding layer
+    - a configurable embedding layer
     - a linear classification layer
 
-    In this example, we use a `box-embedding` layer to generate the embeddings
-    of the boxes. It is composed of a text encoder that embeds the text features of the
-    boxes and a layout encoder that embeds the layout features of the boxes.
-    These two embeddings are summed and passed through an optional `contextualizer`,
-    here a `box-transformer`.
+    In this example, we use a simple CNN-based embedding layer (`sub-box-cnn-pooler`),
+    which applies a stack of CNN layers to the embeddings computed by a text embedding
+    layer (`simple-text-embedding`).
 
     === "API-based"
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,8 @@ theme:
     - navigation.tracking
     - navigation.instant
     - navigation.indexes
+    - navigation.prune
+    - navigation.top
     - content.code.annotate
 
 nav:
@@ -37,6 +39,7 @@ nav:
       - recipes/extension.md
       - recipes/annotation.md
   - Pipes:
+      - pipes/index.md
       - Embeddings:
         - pipes/embeddings/index.md
         - pipes/embeddings/simple-text-embedding.md
@@ -59,7 +62,6 @@ nav:
       - Aggregators:
         - pipes/aggregators/index.md
         - pipes/aggregators/simple-aggregator.md
-      - pipes/index.md
   - Layers:
       - layers/index.md
       - layers/box-transformer.md
@@ -125,7 +127,6 @@ plugins:
             show_root_toc_entry: false
             show_signature: false
             merge_init_into_class: true
-  - autolinks
   - glightbox:
       touchNavigation: true
       loop: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ tests = "pytest --cov=edspdf --cov-report=term-missing --cov-report=xml"
 [tool.hatch.envs.docs]
 dependencies = [
     "mike~=1.1.2",
-    "mkdocs@git+https://github.com/mkdocs/mkdocs.git@5af8bd30538ff8f0cfb698c8b90c3020da319f92",
+    "mkdocs~=1.5.2",
     "mkdocstrings~=0.20",
     "mkdocstrings-python~=1.1",
     "mkdocs-autorefs@git+https://github.com/percevalw/mkdocs-autorefs.git@0.4.1.post0",
@@ -71,6 +71,9 @@ dependencies = [
     "mkdocs-material~=9.1.0",
     "mkdocs-glightbox~=0.3.1",
     "pybtex~=0.24.0",
+    "lxml",
+    "edspdf-mupdf",
+    "edspdf-poppler",
 ]
 
 [tool.hatch.envs.docs.scripts]
@@ -111,7 +114,6 @@ path = "edspdf/__init__.py"
 "multiprocessing" = "edspdf.accelerators.multiprocessing:MultiprocessingAccelerator"
 
 [project.entry-points."mkdocs.plugins"]
-
 "bibtex" = "docs.scripts.bibtex:BibTexPlugin"
 
 [tool.interrogate]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Changelog

### Fixed

- Fix typing to allow passing an accelerator dict to `Pipeline.pipe(...)`
- Removed multiprocessing accelerator debug output
- Fixed absolute links in github-pages docs (e.g. image assets)

### Changed

- Added auto-links to components in the docs (by comparing span contents with entry points)

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
