### PR TITLE
fix: allow recursive pdf file searching

### DIFF
--- a/edspdf/data/files.py
+++ b/edspdf/data/files.py
@@ -1,6 +1,7 @@
 # ruff: noqa: F401
 import json
 import os
+import sys
 from collections import Counter
 from pathlib import Path
 from typing import (
@@ -39,6 +40,7 @@ class FileReader(BaseReader):
         keep_ipynb_checkpoints: bool = False,
         load_annotations: bool = False,
         filesystem: Optional[Any] = None,
+        recursive: bool = False,
     ):
         super().__init__()
 
@@ -66,9 +68,14 @@ class FileReader(BaseReader):
         if not self.filesystem.exists(path):
             raise FileNotFoundError(f"Path {path} does not exist")
 
+        assert sys.version_info >= (3, 8) or not recursive, (
+            "Recursive reading is only supported with Python 3.8 or higher. "
+            "Please upgrade your Python version or set `recursive=False`."
+        )
+        glob_str = "**/*.pdf" if recursive else "*.pdf"
         self.files: List[str] = [
             file
-            for file in self.filesystem.glob(os.path.join(str(self.path), "*.pdf"))
+            for file in self.filesystem.glob(os.path.join(str(self.path), glob_str))
             if (keep_ipynb_checkpoints or ".ipynb_checkpoints" not in str(file))
             and (
                 not load_annotations

--- a/edspdf/data/files.py
+++ b/edspdf/data/files.py
@@ -189,6 +189,7 @@ def read_files(
     load_annotations: bool = False,
     converter: Optional[Union[str, Callable]] = None,
     filesystem: Optional[Any] = None,
+    recursive: Optional[bool] = False,
     **kwargs,
 ) -> LazyCollection:
     """
@@ -271,6 +272,7 @@ def read_files(
             keep_ipynb_checkpoints=keep_ipynb_checkpoints,
             load_annotations=load_annotations,
             filesystem=filesystem,
+            recursive=recursive,
         )
     )
     if converter:

--- a/tests/core/test_data.py
+++ b/tests/core/test_data.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 from pathlib import Path
 
 import pandas as pd
@@ -97,7 +98,10 @@ def parquet_file(tmp_path_factory, request):
     os.chdir(request.fspath.dirname)
     tmp_path = tmp_path_factory.mktemp("test_input_parquet")
     path = tmp_path / "input_test.pq"
-    docs = edspdf.data.read_files("file://" + os.path.abspath("../resources"))
+    docs = edspdf.data.read_files(
+        "file://" + os.path.abspath("../resources"),
+        recursive=sys.version_info >= (3, 8),
+    )
     docs.write_parquet(
         path,
         converter=lambda x: {


### PR DESCRIPTION
## Description

Allow PDFs in subfolders to be found when `edspdf.data.read_files(path)`

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
