### PR TITLE
Fix empty batches & update data API

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,9 +44,24 @@ jobs:
       - name: Test with Pytest on Python ${{ matrix.python-version }}
         run: hatch run tests
 
-      - name: Upload coverage
-        uses: codecov/codecov-action@v2
-        if: matrix.python-version == '3.10'
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-data-${{ matrix.python-version }}
+          path: .coverage.*
+          if-no-files-found: ignore
+          include-hidden-files: true
+
+  Coverage:
+    name: Coverage
+    needs: Pytest
+    uses: aphp/foldedtensor/.github/workflows/coverage.yml@main
+    with:
+      base-branch: main
+      coverage-data-pattern: coverage-data-*
+      coverage-report: coverage.txt
+      coverage-badge: coverage.svg
+      coverage-branch: coverage
 
   Documentation:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Tests](https://img.shields.io/github/actions/workflow/status/aphp/edspdf/tests.yml?branch=main&label=tests&style=flat-square)
 [![Documentation](https://img.shields.io/github/actions/workflow/status/aphp/edspdf/documentation.yml?branch=main&label=docs&style=flat-square)](https://aphp.github.io/edspdf/latest/)
 [![PyPI](https://img.shields.io/pypi/v/edspdf?color=blue&style=flat-square)](https://pypi.org/project/edspdf/)
-[![Codecov](https://img.shields.io/codecov/c/github/aphp/edspdf?logo=codecov&style=flat-square)](https://codecov.io/gh/aphp/edspdf)
+[![Coverage](https://raw.githubusercontent.com/aphp/edspdf/coverage/coverage.svg)](https://raw.githubusercontent.com/aphp/edspdf/coverage/coverage.txt)
 [![DOI](https://zenodo.org/badge/517726737.svg)](https://zenodo.org/badge/latestdoi/517726737)
 
 # EDS-PDF

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Batches full of empty content boxes no longer crash the `huggingface-embedding` component
+- Ensure models are always loaded in non training mode
 
 ## v0.9.1
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Batches full of empty content boxes no longer crash the `huggingface-embedding` component
+
 ## v0.9.1
 
 ### Fixed

--- a/changelog.md
+++ b/changelog.md
@@ -2,10 +2,17 @@
 
 ## Unreleased
 
+### Changed
+
+- Default to fp16 when inferring with gpu
+- Support `inputs` parameter in `TrainablePipe.postprocess(...)` method (as in edsnlp)
+- We now check that the user isn't trying to write a single file in a split fashion (when `write_in_worker is True ` or `num_rows_per_file is not None`) and raise an error if they do
+
 ### Fixed
 
 - Batches full of empty content boxes no longer crash the `huggingface-embedding` component
 - Ensure models are always loaded in non training mode
+- Improved performance of `edspdf.data` methods over a filesystem (`fs` parameter)
 
 ## v0.9.1
 

--- a/docs/trainable-pipes.md
+++ b/docs/trainable-pipes.md
@@ -53,7 +53,7 @@ Additionally, there is a fifth method:
 Here is an example of a trainable component:
 
 ```python
-from typing import Any, Dict, Iterable, Sequence
+from typing import Any, Dict, Iterable, Sequence, List
 
 import torch
 from tqdm import tqdm
@@ -114,7 +114,12 @@ class MyComponent(TrainablePipe):
 
         return output
 
-    def postprocess(self, docs: Sequence[PDFDoc], output: Dict) -> Sequence[PDFDoc]:
+    def postprocess(
+        self,
+        docs: Sequence[PDFDoc],
+        output: Dict,
+        inputs: List[Dict[str, Any]],
+    ) -> Sequence[PDFDoc]:
         # Annotate the docs with the outputs of the forward method
         ...
         return docs

--- a/edspdf/lazy_collection.py
+++ b/edspdf/lazy_collection.py
@@ -325,6 +325,37 @@ class LazyCollection(metaclass=MetaLazyCollection):
             pipe.to(device)
         return self
 
+    def train(self, mode=True):
+        """
+        Enables training mode on pytorch modules
+
+        Parameters
+        ----------
+        mode: bool
+            Whether to enable training or not
+        """
+
+        class context:
+            def __enter__(self):
+                pass
+
+            def __exit__(ctx_self, type, value, traceback):
+                for name, proc in procs:
+                    proc.train(was_training[name])
+
+        procs = [x for x in self.torch_components() if hasattr(x[1], "train")]
+        was_training = {name: proc.training for name, proc in procs}
+        for name, proc in procs:
+            proc.train(mode)
+
+        return context()
+
+    def eval(self):
+        """
+        Enables evaluation mode on pytorch modules
+        """
+        return self.train(False)
+
     def worker_copy(self):
         return LazyCollection(
             reader=self.reader.worker_copy(),

--- a/edspdf/pipeline.py
+++ b/edspdf/pipeline.py
@@ -811,6 +811,7 @@ class Pipeline:
             os.chdir(pwd)
 
         self._path = path  # type: ignore[assignment]
+        self.train(False)
         return self
 
     # override config property getter to remove "factory" key from components

--- a/edspdf/pipes/classifiers/trainable.py
+++ b/edspdf/pipes/classifiers/trainable.py
@@ -1,7 +1,7 @@
 import json
 import os
 from pathlib import Path
-from typing import Any, Dict, Iterable, Sequence, Set
+from typing import Any, Dict, Iterable, List, Sequence, Set
 
 import torch
 import torch.nn.functional as F
@@ -201,7 +201,12 @@ class TrainableClassifier(TrainablePipe[Dict[str, Any]]):
 
         return output
 
-    def postprocess(self, docs: Sequence[PDFDoc], output: Dict) -> Sequence[PDFDoc]:
+    def postprocess(
+        self,
+        docs: Sequence[PDFDoc],
+        output: Dict,
+        inputs: List[Dict[str, Any]],
+    ) -> Sequence[PDFDoc]:
         for b, label in zip(
             (b for doc in docs for b in doc.text_boxes),
             output["labels"].tolist(),

--- a/edspdf/pipes/embeddings/huggingface_embedding.py
+++ b/edspdf/pipes/embeddings/huggingface_embedding.py
@@ -291,7 +291,9 @@ class HuggingfaceEmbedding(TrainablePipe[EmbeddingOutput]):
         last_after_one = max(0, len(line_window_offsets_flat) - 1)
         line_window_offsets_flat = as_folded_tensor(
             # discard the last offset, since we start from 0 and add each line length
-            data=torch.as_tensor(line_window_offsets_flat[:last_after_one]),
+            data=torch.as_tensor(
+                line_window_offsets_flat[:last_after_one], dtype=torch.long
+            ),
             data_dims=("line",),
             full_names=("sample", "page", "line"),
             lengths=line_window_indices.lengths[:-1],

--- a/edspdf/processing/utils.py
+++ b/edspdf/processing/utils.py
@@ -1,0 +1,85 @@
+import types
+from typing import Iterable, List, TypeVar
+
+from edspdf.utils.collections import batchify
+
+
+def apply_basic_pipes(docs, pipes):
+    for name, pipe, kwargs in pipes:
+        if hasattr(pipe, "batch_process"):
+            docs = pipe.batch_process(docs)
+        else:
+            results = []
+            for doc in docs:
+                res = pipe(doc, **kwargs)
+                if isinstance(res, types.GeneratorType):
+                    results.extend(res)
+                else:
+                    results.append(res)
+            docs = results
+    return docs
+
+
+T = TypeVar("T")
+
+
+def batchify_with_counts(
+    iterable,
+    batch_size,
+):
+    total = 0
+    batch = []
+    for item, count in iterable:
+        if len(batch) > 0 and total + count > batch_size:
+            yield batch, total
+            batch = []
+            total = 0
+        batch.append(item)
+        total += count
+    if len(batch) > 0:
+        yield batch, total
+
+
+def batchify_by_content_boxes(
+    iterable: Iterable[T],
+    batch_size: int,
+    drop_last: bool = False,
+) -> Iterable[List[T]]:
+    batch = []
+    total = 0
+    for item in iterable:
+        count = len(item.content_boxes)
+        if len(batch) > 0 and total + count > batch_size:
+            yield batch
+            batch = []
+            total = 0
+        batch.append(item)
+        total += count
+    if len(batch) > 0 and not drop_last:
+        yield batch
+
+
+def batchify_by_pages(
+    iterable: Iterable[T],
+    batch_size: int,
+    drop_last: bool = False,
+) -> Iterable[List[T]]:
+    batch = []
+    total = 0
+    for item in iterable:
+        count = len(item.pages)
+        if len(batch) > 0 and total + count > batch_size:
+            yield batch
+            batch = []
+            total = 0
+        batch.append(item)
+        total += count
+    if len(batch) > 0 and not drop_last:
+        yield batch
+
+
+batchify_fns = {
+    "content_boxes": batchify_by_content_boxes,
+    "pages": batchify_by_pages,
+    "docs": batchify,
+}

--- a/edspdf/utils/file_system.py
+++ b/edspdf/utils/file_system.py
@@ -1,0 +1,62 @@
+import os
+import re
+from pathlib import Path
+from typing import Optional, Tuple, Union
+
+import fsspec.implementations.local
+import pyarrow.fs
+from fsspec import AbstractFileSystem
+from fsspec import __version__ as fsspec_version
+from fsspec.implementations.arrow import ArrowFSWrapper
+
+FileSystem = Union[AbstractFileSystem, pyarrow.fs.FileSystem]
+
+if fsspec_version < "2023.3.0":
+    # Ugly hack to make fsspec's arrow implementation work in python 3.7
+    # since arrow requires files to be seekable, and the default fsspec
+    # open(..., seekable) parameter is False
+    # See https://github.com/fsspec/filesystem_spec/pull/1186
+    ArrowFSWrapper._open.__wrapped__.__defaults__ = ("rb", None, True)
+
+
+def walk_match(
+    fs: FileSystem,
+    root: str,
+    file_pattern: str,
+) -> list:
+    return [
+        os.path.join(dirpath, f)
+        for dirpath, dirnames, files in fs.walk(root)
+        for f in files
+        if re.match(file_pattern, f)
+    ]
+
+
+def normalize_fs_path(
+    filesystem: Optional[FileSystem],
+    path: Union[str, Path],
+) -> Tuple[AbstractFileSystem, str]:
+    has_protocol = isinstance(path, str) and "://" in path
+    filesystem = (
+        ArrowFSWrapper(filesystem)
+        if isinstance(filesystem, pyarrow.fs.FileSystem)
+        else filesystem
+    )
+
+    # We need to detect the fs from the path
+    if filesystem is None or has_protocol:
+        uri: str = path if has_protocol else f"file://{os.path.abspath(path)}"
+        inferred_fs, fs_path = fsspec.core.url_to_fs(uri)
+        inferred_fs: fsspec.AbstractFileSystem
+        filesystem = filesystem or inferred_fs
+        assert inferred_fs.protocol == filesystem.protocol, (
+            f"Protocol {inferred_fs.protocol} in path does not match "
+            f"filesystem {filesystem.protocol}"
+        )
+        path = fs_path  # path without protocol
+
+    return (
+        ArrowFSWrapper(filesystem)
+        if isinstance(filesystem, pyarrow.fs.FileSystem)
+        else filesystem
+    ), str(path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
 ]
 
 [tool.hatch.envs.default.scripts]
-tests = "pytest --cov=edspdf --cov-report=term-missing --cov-report=xml"
+tests = "coverage run -m pytest"
 
 [tool.hatch.envs.docs]
 dependencies = [
@@ -141,13 +141,10 @@ whitelist-regex = []
 color = true
 omit-covered-files = false
 
-[tool.coverage.run]
-concurrency = ["multiprocessing"]
-
 [tool.coverage.report]
-include = [
-    "edspdf/*",
-]
+precision = 2
+include = ["edspdf/*"]
+omit = ["tests/*"]
 exclude_lines = [
     "def __repr__",
     "if __name__ == .__main__.:",
@@ -162,6 +159,11 @@ exclude_lines = [
     "class .*\\bProtocol\\):",
     "@(abc\\.)?abstractmethod",
 ]
+
+[tool.coverage.run]
+include = ["edspdf/*"]
+concurrency = ["multiprocessing", "thread"]
+parallel = true
 
 [tool.pytest.ini_options]
 testpaths = [

--- a/tests/core/test_data.py
+++ b/tests/core/test_data.py
@@ -66,11 +66,11 @@ def test_write_data(
     )
     if write_mode == "parquet":
         docs.write_parquet(
-            "file://" + str(tmp_path / "parquet" / "test.parquet"),
+            "file://" + str(tmp_path / "parquet" / "test"),
             converter=box_converter,
             write_in_worker=write_in_worker,
         )
-        df = pd.read_parquet("file://" + str(tmp_path / "parquet" / "test.parquet"))
+        df = pd.read_parquet("file://" + str(tmp_path / "parquet" / "test"))
     elif write_mode == "pandas":
         if write_in_worker:
             pytest.skip()

--- a/tests/recipes/test_train.py
+++ b/tests/recipes/test_train.py
@@ -333,7 +333,16 @@ def test_function_huggingface(pdf, error_pdf, change_test_dir, dummy_dataset, tm
     docs = list(data_adapter(model))
 
     model = edspdf.load(tmp_path / "last-model")
+    assert not model.get_pipe("embedding").training
 
+    weird_doc: PDFDoc = model.get_pipe("extractor")(pdf)
+    for line in weird_doc.text_boxes:
+        line.text = ""
+    list(model.pipe([]))
+    with model.select_pipes(disable=["extractor"]):
+        list(model.pipe([weird_doc] * 4))
+    list(model.pipe([error_pdf] * 4))
+    list(model.pipe([]))
     list(model.pipe([pdf] * 2 + [error_pdf] * 2))
     output = model(PDFDoc(content=pdf))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

### Changed

- Default to fp16 when inferring with gpu
- Support `inputs` parameter in `TrainablePipe.postprocess(...)` method (as in edsnlp)
- We now check that the user isn't trying to write a single file in a split fashion (when `write_in_worker is True ` or `num_rows_per_file is not None`) and raise an error if they do

### Fixed

- Batches full of empty content boxes no longer crash the `huggingface-embedding` component
- Ensure models are always loaded in non training mode
- Improved performance of `edspdf.data` methods over a filesystem (`fs` parameter)

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
